### PR TITLE
chore: remove tracing-subscriber from composer

### DIFF
--- a/composer/Cargo.toml
+++ b/composer/Cargo.toml
@@ -18,14 +18,13 @@ prost-build = "0.8.0"
 prost = "0.8.0"
 prost-derive = "0.8.0"
 prost-types = "0.8.0"
-tokio = { version = "1.12.0", features = [ "full" ] }
-futures = "0.3.17"
-tracing = "0.1.28"
-tracing-subscriber = "0.2.24"
+tokio = { version = "1.20.1", features = [ "full" ] }
+futures = "0.3.21"
+tracing = "0.1.35"
 tonic = { version = "0.5.2", optional = true }
-once_cell = "1.8.0"
-ipnetwork = "0.18.0"
+once_cell = "1.13.0"
+ipnetwork = "0.20.0"
 bollard = "0.11.0"
-serde = { version = "1.0.130", features = ["derive"] }
-serde_derive = "1.0.130"
-serde_json = "1.0.68"
+serde = { version = "1.0.140", features = ["derive"] }
+serde_derive = "1.0.140"
+serde_json = "1.0.82"

--- a/composer/src/composer.rs
+++ b/composer/src/composer.rs
@@ -725,23 +725,6 @@ impl Builder {
         self
     }
 
-    /// setup tracing for the cargo test code with `RUST_LOG` const
-    pub fn with_default_tracing(self) -> Self {
-        self.with_tracing(RUST_LOG_DEFAULT)
-    }
-
-    /// setup tracing for the cargo test code with `filter`
-    /// ignore when called multiple times
-    pub fn with_tracing(self, filter: &str) -> Self {
-        let builder = if let Ok(filter) = tracing_subscriber::EnvFilter::try_from_default_env() {
-            tracing_subscriber::fmt().with_env_filter(filter)
-        } else {
-            tracing_subscriber::fmt().with_env_filter(filter)
-        };
-        builder.try_init().ok();
-        self
-    }
-
     /// with the following shutdown order
     pub fn with_shutdown_order(mut self, shutdown: Vec<String>) -> Builder {
         self.shutdown_order = shutdown;


### PR DESCRIPTION
Libraries should usually only use the tracing crate.
Bonus: Update toml versions

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>