### PR TITLE
feat(nvmeadm): return subsystem object for representing nvme connections

### DIFF
--- a/nvmeadm/src/nvmf_subsystem.rs
+++ b/nvmeadm/src/nvmf_subsystem.rs
@@ -7,6 +7,8 @@ use glob::glob;
 use snafu::ResultExt;
 use std::{fs::OpenOptions, io::Write, path::Path, str::FromStr};
 
+pub const SYSFS_NVME_CTRLR_PREFIX: &str = "/sys/devices/virtual/nvme-fabrics/ctl";
+
 /// Subsystem struct shows us all the connect fabrics. This does not include
 /// NVMe devices that are connected by trtype=PCIe
 #[derive(Default, Clone, Debug)]
@@ -34,7 +36,7 @@ impl Subsystem {
     /// that does not contain a value that is being read in the implementation
     pub fn new(source: &Path) -> Result<Self, NvmeError> {
         let name = source
-            .strip_prefix("/sys/devices/virtual/nvme-fabrics/ctl")
+            .strip_prefix(SYSFS_NVME_CTRLR_PREFIX)
             .context(InvalidPath {
                 path: format!("{:?}", source),
             })?

--- a/nvmeadm/tests/discovery_test.rs
+++ b/nvmeadm/tests/discovery_test.rs
@@ -13,13 +13,7 @@ use std::{
 static CONFIG_TEXT: &str = "nexus_opts:
   nvmf_nexus_port: 4422
   nvmf_replica_port: NVMF_PORT
-  iscsi_enable: false
-nvmf_tcp_tgt_conf:
-  max_namespaces: 2
-# although not used we still have to reduce mem requirements for iSCSI
-iscsi_tgt_conf:
-  max_sessions: 1
-  max_connections_per_session: 1
+  nvmf_enable: true
 ";
 
 const CONFIG_FILE: &str = "/tmp/nvmeadm_nvmf_target.yaml";
@@ -191,6 +185,13 @@ fn disconnect_test() {
 
 #[test]
 fn test_against_real_target() {
+    // Disconnect all pre-existing NVMe connections to make sure new controller
+    // always gets id = 0.
+    let _nvme_disconnect = Command::new("nvme")
+        .arg("disconnect-all")
+        .spawn()
+        .expect("Failed to cleanup NVMe connections !");
+
     // Start an SPDK-based nvmf target
     let _target = NvmfTarget::new(CONFIG_FILE, &TARGET_PORT.to_string());
 
@@ -210,9 +211,16 @@ fn test_against_real_target() {
         .expect_err("Should NOT be able to connect to invalid target");
 
     // Check that we CAN connect to an NQN that is served
-    let _expect_to_connect = explorer
+    let subsystem = explorer
         .connect(SERVED_DISK_NQN)
         .expect("Problem connecting to valid target");
+
+    // Since there are no other NVMe controllers exist, our controller
+    // must be nvme0.
+    // Make sure subsystem represents the same controller object and is live.
+    assert_eq!(subsystem.name, "nvme0");
+    assert_eq!(subsystem.instance, 0);
+    assert_eq!(subsystem.state, "live");
 
     // allow the part scan to complete for most cases
     std::thread::sleep(std::time::Duration::from_secs(1));


### PR DESCRIPTION
ConnectArgs::connect() now returns a Subsystem object,  which simplifies
library usage and eliminates the need for library clients to manually parse
a cryptic connection string that represent a connection to get a Subsystem.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>