### PR TITLE
feat(nvmeadm): support of subsystem state synchronisation

### DIFF
--- a/nvmeadm/src/nvmf_subsystem.rs
+++ b/nvmeadm/src/nvmf_subsystem.rs
@@ -71,6 +71,17 @@ impl Subsystem {
             model,
         })
     }
+    /// Synchronize in-memory state of this subsystem with system's state.
+    /// The folowing is updated: state
+    pub fn sync(&mut self) -> Result<(), NvmeError> {
+        let filename = format!("{}/{}", SYSFS_NVME_CTRLR_PREFIX, self.name);
+        let path = Path::new(&filename);
+        let state = parse_value::<String>(path, "state")?;
+
+        self.state = state;
+        Ok(())
+    }
+
     /// issue a rescan to the controller to find new namespaces
     pub fn rescan(&self) -> Result<(), NvmeError> {
         let filename = format!("/sys/class/nvme/{}/rescan_controller", self.name);

--- a/nvmeadm/tests/discovery_test.rs
+++ b/nvmeadm/tests/discovery_test.rs
@@ -211,7 +211,7 @@ fn test_against_real_target() {
         .expect_err("Should NOT be able to connect to invalid target");
 
     // Check that we CAN connect to an NQN that is served
-    let subsystem = explorer
+    let mut subsystem = explorer
         .connect(SERVED_DISK_NQN)
         .expect("Problem connecting to valid target");
 
@@ -220,6 +220,10 @@ fn test_against_real_target() {
     // Make sure subsystem represents the same controller object and is live.
     assert_eq!(subsystem.name, "nvme0");
     assert_eq!(subsystem.instance, 0);
+    assert_eq!(subsystem.state, "live");
+
+    // Should be able to sync the subsystem.
+    subsystem.sync().expect("Failed to sync subsystem's state");
     assert_eq!(subsystem.state, "live");
 
     // allow the part scan to complete for most cases


### PR DESCRIPTION
NVMe Subsystem represents an in-memory snapshot of an NVMe subsystem
that exists on the system. When state of the underlying subsystem changes,
there is no possibility to get this change reflected in existing Subsystem object
other than recreate it from scratch.
This change introduces a new function to allow explicit synchronisation on demand
for existing Subsystem objects.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>