### PR TITLE
chore: get subsystem with nqn to list all subsystems for volume

### DIFF
--- a/nvmeadm/src/error.rs
+++ b/nvmeadm/src/error.rs
@@ -19,8 +19,8 @@ pub enum NvmeError {
         filename: String,
         source: std::io::Error,
     },
-    #[snafu(display("nqn: {} not found", text))]
-    NqnNotFound { text: String },
+    #[snafu(display("No Nvmf subsystem found for the nqn: {}", nqn))]
+    NqnNotFound { nqn: String },
     #[snafu(display("No nvmf subsystems found"))]
     NoSubsystems,
     #[snafu(display(
@@ -34,8 +34,6 @@ pub enum NvmeError {
         host: String,
         port: u16,
     },
-    #[snafu(display("No Nvmf Subsystem found for nqn :{}", nqn))]
-    NoSubsytemFound { nqn: String },
     #[snafu(display("Connect in progress"))]
     ConnectInProgress,
     #[snafu(display("NVMe connect failed: {}, {}", filename, source))]

--- a/nvmeadm/src/error.rs
+++ b/nvmeadm/src/error.rs
@@ -34,6 +34,8 @@ pub enum NvmeError {
         host: String,
         port: u16,
     },
+    #[snafu(display("No Nvmf Subsystem found for nqn :{}", nqn))]
+    NoSubsytemFound { nqn: String },
     #[snafu(display("Connect in progress"))]
     ConnectInProgress,
     #[snafu(display("NVMe connect failed: {}, {}", filename, source))]

--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -418,7 +418,7 @@ impl Discovery {
                 }),
             }
         } else {
-            Err(NvmeError::NqnNotFound { text: nqn.into() })
+            Err(NvmeError::NqnNotFound { nqn: nqn.into() })
         }
     }
 }

--- a/nvmeadm/src/nvmf_subsystem.rs
+++ b/nvmeadm/src/nvmf_subsystem.rs
@@ -172,6 +172,24 @@ impl Subsystem {
             Some(subsys) => Ok(subsys),
         }
     }
+
+    /// Gets all Nvme subsystems registered for a given volume.
+    pub fn get_from_nqn(nqn: &str) -> Result<Vec<Subsystem>, NvmeError> {
+        let nvme_subsystems = NvmeSubsystems::new()?;
+        let mut nvme_paths = vec![];
+        for path in nvme_subsystems.flatten() {
+            if path.nqn == nqn && (path.state == "live" || path.state == "connecting") {
+                nvme_paths.push(path);
+            }
+        }
+        if !nvme_paths.is_empty() {
+            Err(NvmeError::NoSubsytemFound {
+                nqn: nqn.to_string(),
+            })
+        } else {
+            Ok(nvme_paths)
+        }
+    }
 }
 
 /// List of subsystems found on the system.

--- a/nvmeadm/src/nvmf_subsystem.rs
+++ b/nvmeadm/src/nvmf_subsystem.rs
@@ -173,17 +173,17 @@ impl Subsystem {
         }
     }
 
-    /// Gets all Nvme subsystems registered for a given volume.
-    pub fn get_from_nqn(nqn: &str) -> Result<Vec<Subsystem>, NvmeError> {
+    /// Gets all Nvme subsystem registered for a given nqn.
+    pub fn try_from_nqn(nqn: &str) -> Result<Vec<Subsystem>, NvmeError> {
         let nvme_subsystems = NvmeSubsystems::new()?;
         let mut nvme_paths = vec![];
         for path in nvme_subsystems.flatten() {
-            if path.nqn == nqn && (path.state == "live" || path.state == "connecting") {
+            if path.nqn == nqn {
                 nvme_paths.push(path);
             }
         }
-        if !nvme_paths.is_empty() {
-            Err(NvmeError::NoSubsytemFound {
+        if nvme_paths.is_empty() {
+            Err(NvmeError::NqnNotFound {
                 nqn: nqn.to_string(),
             })
         } else {


### PR DESCRIPTION
This PR adds method to get all subsystems registered with the supplied nqn.

Signed-off-by: Abhilash Shetty <abhilash.shetty@datacore.com>