### PR TITLE
chore: allow build on non-linux

### DIFF
--- a/devinfo/Cargo.toml
+++ b/devinfo/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 
 [dependencies]
 snafu = "0.7.1"
-udev = "0.6.2"
 url = "2.2.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 [build-dependencies]
 bindgen = "0.59.1"
+
+[target.'cfg(target_os="linux")'.dependencies]
+udev = "0.6.2"

--- a/devinfo/build.rs
+++ b/devinfo/build.rs
@@ -1,4 +1,7 @@
+#[cfg(target_os = "linux")]
 use std::{env, path::PathBuf};
+
+#[cfg(target_os = "linux")]
 fn main() {
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
@@ -13,3 +16,6 @@ fn main() {
 
     println!("cargo:rustc-link-lib=blkid");
 }
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/devinfo/src/lib.rs
+++ b/devinfo/src/lib.rs
@@ -7,7 +7,9 @@ pub mod mountinfo;
 pub mod partition;
 
 #[allow(non_camel_case_types)]
+#[cfg(target_os = "linux")]
 pub mod blkid;
+
 #[derive(Debug, Snafu)]
 pub enum DevInfoError {
     #[snafu(display("Device {} not found", path))]


### PR DESCRIPTION
This is done by disabling blkid and udev build.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>