### PR TITLE
feat: add features to control git-version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "h2"]
 	path = h2
 	url = https://github.com/openebs/h2.git
+[submodule "rust-git-version"]
+	path = rust-git-version
+	url = https://github.com/openebs/rust-git-version.git
+	branch = mayastor

--- a/version-info/Cargo.toml
+++ b/version-info/Cargo.toml
@@ -7,5 +7,10 @@ authors = [
 ]
 
 [dependencies]
-git-version = "0.3.5"
+git-version-macro = { path = "../rust-git-version/git-version-macro" }
 regex = "1"
+
+[features]
+default = [ "default-git-versions" ]
+default-git-versions = [ ]
+git-version-stale = [ "default-git-versions" ]

--- a/version-info/src/lib.rs
+++ b/version-info/src/lib.rs
@@ -1,5 +1,6 @@
 mod git_utils;
 mod version_info;
+#[cfg(feature = "default-git-versions")]
 pub use git_utils::{long_raw_version_str, raw_version_str, raw_version_string};
 pub use version_info::VersionInfo;
 pub mod macros;

--- a/version-info/src/macros.rs
+++ b/version-info/src/macros.rs
@@ -15,6 +15,20 @@ macro_rules! version_info {
             },
         )
     };
+    ($version:expr) => {
+        $crate::VersionInfo::new(
+            String::from($version),
+            String::from(env!("CARGO_PKG_NAME")),
+            String::from(env!("CARGO_PKG_DESCRIPTION")),
+            String::from(env!("CARGO_PKG_VERSION")),
+            option_env!("CARGO_BIN_NAME").map(|s| s.to_string()),
+            if cfg!(debug_assertions) {
+                String::from("debug")
+            } else {
+                String::from("")
+            },
+        )
+    };
 }
 
 /// Returns a version info instance.


### PR DESCRIPTION
Added git dependencies:
https://github.com/fusion-engineering/rust-git-version/pull/19

This allows us to avoid rebuilds when staging changes.

Also added another feature to avoid rebuilds altogether. Eg: if git versions are specified via env variable then we don't need to use git from within the rust-build at all. This is fine for most dev setups if we don't care about versions locally testing.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>