### PR TITLE
chore: remove default deps

### DIFF
--- a/nvmeadm/Cargo.toml
+++ b/nvmeadm/Cargo.toml
@@ -10,7 +10,7 @@ enum-primitive-derive = "0.2.2"
 glob = "0.3.1"
 ioctl-gen = "0.1.1"
 libc = "0.2.139"
-nix = "0.26.2"
+nix = { version = "0.26.2", default-features = false, features = [ "ioctl" ] }
 num-traits = "0.2.15"
 once_cell = "1.17.0"
 snafu = "0.7.4"


### PR DESCRIPTION
We only really use the io feature.