### PR TITLE
feat(eventing): add proto serializable timestamp

### DIFF
--- a/events-api/Cargo.toml
+++ b/events-api/Cargo.toml
@@ -23,3 +23,4 @@ prost = "0.11.9"
 prost-wkt-types = "0.4.2"
 chrono = "0.4.31"
 once_cell = "1.18.0"
+prost-extend = { path = "../prost-extend" }

--- a/events-api/build.rs
+++ b/events-api/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     tonic_build::configure()
         .type_attribute(".", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .extern_path(".google.protobuf.Timestamp", "::prost_wkt_types::Timestamp")
+        .extern_path(".google.protobuf.Timestamp", "::prost_extend::Timestamp")
         .compile(&["protobuf/v1/event.proto"], &["protobuf/"])
         .unwrap_or_else(|e| panic!("event v1 protobuf compilation failed: {e}"));
 }

--- a/events-api/src/event_traits.rs
+++ b/events-api/src/event_traits.rs
@@ -124,7 +124,7 @@ mod test {
         let event_source = EventSource::new("".to_string());
         let event_meta = EventMeta::from_source(event_source);
         assert!(!event_meta.id.is_empty());
-        assert!(!event_meta.timestamp.unwrap().to_string().is_empty());
+        assert!(event_meta.timestamp.is_some());
         assert_eq!(event_meta.version, Version::V1 as i32);
         assert_ne!(event_meta.source, None);
     }

--- a/prost-extend/Cargo.toml
+++ b/prost-extend/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "prost-extend"
+version = "0.1.0"
+edition = "2021"
+
+
+[build-dependencies]
+tonic-build = "0.8.4"
+
+[dependencies]
+chrono = "0.4.26"
+serde = "1.0.183"
+tonic = "0.8.3"
+prost = "0.11.9"

--- a/prost-extend/build.rs
+++ b/prost-extend/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    tonic_build::configure()
+        .compile(&["protobuf/v1/pb_time.proto"], &["protobuf/"])
+        .unwrap_or_else(|e| panic!("prost-extend v1 protobuf compilation failed: {e}"));
+}

--- a/prost-extend/protobuf/v1/pb_time.proto
+++ b/prost-extend/protobuf/v1/pb_time.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+import "google/protobuf/wrappers.proto";
+
+package v1.pb_time;
+
+
+message Timestamp {
+    // Number of non-leap seconds since January 1, 1970 0:00:00 UTC - UNIX timestamp
+    int64 seconds = 1;
+    // Returns the number of nanoseconds since the last second boundary
+    uint32 nanos = 2;
+}

--- a/prost-extend/src/lib.rs
+++ b/prost-extend/src/lib.rs
@@ -1,0 +1,9 @@
+mod timestamp;
+
+mod common_types {
+    #![allow(clippy::derive_partial_eq_without_eq)]
+    #![allow(clippy::large_enum_variant)]
+    tonic::include_proto!("v1.pb_time");
+}
+
+pub use common_types::Timestamp;

--- a/prost-extend/src/timestamp.rs
+++ b/prost-extend/src/timestamp.rs
@@ -1,0 +1,70 @@
+use std::{fmt, str::FromStr};
+
+use chrono::{DateTime, Utc};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::Timestamp;
+
+impl TryFrom<Timestamp> for DateTime<Utc> {
+    type Error = &'static str;
+
+    fn try_from(value: Timestamp) -> Result<Self, Self::Error> {
+        match DateTime::<Utc>::from_timestamp(value.seconds, value.nanos) {
+            Some(datetime) => Ok(datetime),
+            None => Err("Invalid or out-of-range timestamp"),
+        }
+    }
+}
+
+impl From<DateTime<Utc>> for Timestamp {
+    fn from(dt: DateTime<Utc>) -> Self {
+        Timestamp {
+            seconds: dt.timestamp(),
+            nanos: dt.timestamp_subsec_nanos(),
+        }
+    }
+}
+
+impl Serialize for Timestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        let time_stamp = Timestamp {
+            seconds: self.seconds,
+            nanos: self.nanos,
+        };
+        let datetime = DateTime::<Utc>::try_from(time_stamp).map_err(serde::ser::Error::custom)?;
+        serializer.serialize_str(&format!("{datetime:?}"))
+    }
+}
+
+impl<'de> Deserialize<'de> for Timestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TimestampVisitor;
+
+        impl<'de> Visitor<'de> for TimestampVisitor {
+            type Value = Timestamp;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a timestamp in RFC3339 format")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let utc_datetime = DateTime::<Utc>::from_str(value).map_err(|error| {
+                    serde::de::Error::custom(format!(
+                        "Failed to parse {value} as datetime: {error:?}"
+                    ))
+                })?;
+                Ok(Timestamp::from(utc_datetime))
+            }
+        }
+        deserializer.deserialize_str(TimestampVisitor)
+    }
+}


### PR DESCRIPTION
Added serve-proto crate for serialisable timestamp. Remove dependency on prost-wkt-types::Timestamp.