### PR TITLE
fix(nvmeadm/addr): match for host&port only

### DIFF
--- a/nvmeadm/Cargo.toml
+++ b/nvmeadm/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "nvmeadm"
 version = "1.0.0"
-authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 derive_builder = "0.12.0"


### PR DESCRIPTION
When listing we can't compare the full address with a host:port because the address from the subsystem might have other components such as the source address.
Instead, let's only check if this is the host:port we're interested in.