### PR TITLE
Cherry-Pick from develop into release/2.5

### DIFF
--- a/apis/events/protobuf/v1/event.proto
+++ b/apis/events/protobuf/v1/event.proto
@@ -181,4 +181,8 @@ message NvmePathEventDetails {
 message HostInitiatorEventDetails {
   string host_nqn = 1;
   string subsystem_nqn = 2;
+  // The target on which the host is connected to the subsystem - Nexus/Replica
+  string target = 3;
+  // Target uuid
+  string uuid = 4;
 }

--- a/apis/events/src/event_traits.rs
+++ b/apis/events/src/event_traits.rs
@@ -153,6 +153,19 @@ impl EventSource {
         }
     }
 
+    /// Add target(nexus/replica) details to host event meta data.
+    pub fn with_target_data(mut self, target: &str, uuid: &str) -> Self {
+        if let Some(mut event_details) = self.event_details {
+            if let Some(mut host_initiator_details) = event_details.host_initiator_details {
+                host_initiator_details.target = target.to_string();
+                host_initiator_details.uuid = uuid.to_string();
+                event_details.host_initiator_details = Some(host_initiator_details);
+            }
+            self.event_details = Some(event_details);
+        }
+        self
+    }
+
     /// Add host event specific data to event source.
     pub fn with_host_initiator_data(mut self, host_nqn: &str) -> Self {
         if let Some(mut event_details) = self.event_details {

--- a/apis/io-engine/protobuf/v1/test.proto
+++ b/apis/io-engine/protobuf/v1/test.proto
@@ -8,6 +8,9 @@ package mayastor.v1;
 
 // Service to be used by test code, it is not meant to be used in production!
 service TestRpc {
+  // Get all the features supported by the test service.
+  rpc GetFeatures (google.protobuf.Empty) returns (TestFeatures) {}
+
   // Replica related methods.
   //
   // Wipe a replica using the selected method.
@@ -26,6 +29,13 @@ service TestRpc {
 
   // List existing fault injections.
   rpc ListFaultInjections (ListFaultInjectionsRequest) returns (ListFaultInjectionsReply) {}
+}
+
+message TestFeatures {
+  // Supported wipe methods.
+  repeated WipeOptions.WipeMethod        wipe_methods = 1;
+  // Supported checksum algorithms.
+  repeated WipeOptions.CheckSumAlgorithm   cksum_algs = 2;
 }
 
 message WipeReplicaRequest {

--- a/apis/io-engine/protobuf/v1/test.proto
+++ b/apis/io-engine/protobuf/v1/test.proto
@@ -43,19 +43,28 @@ message WipeReplicaRequest {
 message WipeOptions {
   enum WipeMethod {
     // Don't actually wipe, just pretend.
-    NONE                        = 0;
+    NONE          = 0;
     // Wipe by writing zeroes.
-    WRITE_ZEROES                = 1;
+    WRITE_ZEROES  = 1;
     // Wipe by sending unmap/trim.
-    UNMAP                       = 2;
+    UNMAP         = 2;
     // Wipe by writing a given patter (see write_pattern(6) field).
-    WRITE_PATTERN               = 3;
+    WRITE_PATTERN = 3;
+    // Checksum the bdev.
+    CHECKSUM      = 4;
   }
   // Method used to wipe the bdev.
   WipeMethod        wipe_method = 1;
   // When using WRITE_PATTERN, wipe using this 32bit write pattern
   // Default: 0xDEADBEEF.
   optional uint32 write_pattern = 2;
+
+  enum CheckSumAlgorithm {
+    // The CRC32C is a variant of CRC32.
+    Crc32c = 0;
+  }
+  // When using CHECKSUM, use the following algorithm.
+  CheckSumAlgorithm   cksum_alg = 3;
 }
 
 message StreamWipeOptions {
@@ -88,6 +97,11 @@ message WipeReplicaResponse {
   uint64         remaining_bytes = 8;
   // Duration since the start of the wipe.
   google.protobuf.Duration since = 9;
+  // When using CHECKSUM, output of the algorithm.
+  oneof checksum {
+    // 32bit CRC.
+    uint32 crc32                = 10;
+  }
 }
 
 message FaultInjection {

--- a/apis/io-engine/src/v1.rs
+++ b/apis/io-engine/src/v1.rs
@@ -109,9 +109,10 @@ pub mod test {
     pub use super::pb::{
         test_rpc_client::TestRpcClient,
         test_rpc_server::{TestRpc, TestRpcServer},
-        wipe_options, wipe_replica_request, AddFaultInjectionRequest, FaultInjection,
-        ListFaultInjectionsReply, ListFaultInjectionsRequest, RemoveFaultInjectionRequest,
-        StreamWipeOptions, WipeOptions, WipeReplicaRequest, WipeReplicaResponse,
+        wipe_options, wipe_replica_request, wipe_replica_response, AddFaultInjectionRequest,
+        FaultInjection, ListFaultInjectionsReply, ListFaultInjectionsRequest,
+        RemoveFaultInjectionRequest, StreamWipeOptions, WipeOptions, WipeReplicaRequest,
+        WipeReplicaResponse,
     };
 }
 

--- a/apis/io-engine/src/v1.rs
+++ b/apis/io-engine/src/v1.rs
@@ -111,8 +111,8 @@ pub mod test {
         test_rpc_server::{TestRpc, TestRpcServer},
         wipe_options, wipe_replica_request, wipe_replica_response, AddFaultInjectionRequest,
         FaultInjection, ListFaultInjectionsReply, ListFaultInjectionsRequest,
-        RemoveFaultInjectionRequest, StreamWipeOptions, WipeOptions, WipeReplicaRequest,
-        WipeReplicaResponse,
+        RemoveFaultInjectionRequest, StreamWipeOptions, TestFeatures, WipeOptions,
+        WipeReplicaRequest, WipeReplicaResponse,
     };
 }
 


### PR DESCRIPTION
    feat(test/features): expose test features
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(io-engine/api/cksum): add wipe checksum
    
    Checksums a replica which can be used to verify data between volume replicas.
    For speed sake we're reusing the existing wipe replicas as it's a very good
    fit for this and we can reuse the entire infra around it.
    todo: consider renaming wipe etc
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    feat(eventing): event specific details for host events
    
    Signed-off-by: Vandana Varakantham <vandana.varakantham@datacore.com>
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
