### PR TITLE
fix(devinfo): add consistent read for kernel bug 

### DIFF
--- a/devinfo/Cargo.toml
+++ b/devinfo/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Jeffry Molanus <jeffry.molanus@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+nix = { version = "0.27.1", default-features = false, features = [ "feature" ] }
+semver = "1.0.20"
 snafu = "0.7.5"
 url = "2.4.1"
 uuid = { version = "1.4.1", features = ["v4"] }

--- a/devinfo/src/mountinfo/bytebuf.rs
+++ b/devinfo/src/mountinfo/bytebuf.rs
@@ -1,0 +1,41 @@
+use std::io::{IoSliceMut, Read};
+
+/// This is io::Read capable Sized type. This can wrap around a Vec<u8>.
+pub struct ByteBuf {
+    inner: Vec<u8>,
+}
+
+impl Read for ByteBuf {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.as_slice().read(buf)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> std::io::Result<usize> {
+        self.inner.as_slice().read_vectored(bufs)
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> std::io::Result<usize> {
+        self.inner.as_slice().read_to_end(buf)
+    }
+
+    fn read_to_string(&mut self, buf: &mut String) -> std::io::Result<usize> {
+        self.inner.as_slice().read_to_string(buf)
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+        self.inner.as_slice().read_exact(buf)
+    }
+
+    fn by_ref(&mut self) -> &mut Self
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+impl From<Vec<u8>> for ByteBuf {
+    fn from(inner: Vec<u8>) -> Self {
+        Self { inner }
+    }
+}

--- a/devinfo/src/mountinfo/error.rs
+++ b/devinfo/src/mountinfo/error.rs
@@ -1,0 +1,67 @@
+use std::{
+    error::Error,
+    ffi::OsString,
+    fmt::{Debug, Display, Formatter},
+    path::PathBuf,
+};
+
+pub type Result<T, E = MountInfoError> = std::result::Result<T, E>;
+
+/// Error related to MountInfo, MountIter, SafeMountIter, etc.
+#[derive(Debug)]
+pub enum MountInfoError {
+    Io(std::io::Error),
+    InconsistentRead { filepath: PathBuf, retries: u32 },
+    Nix(nix::Error),
+    ConvertOsStrToStr { source: OsString },
+    Semver(semver::Error),
+}
+
+impl Display for MountInfoError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(ref err) => write!(f, "IO error: {err}"),
+            Self::InconsistentRead {
+                filepath: path,
+                retries,
+            } => write!(
+                f,
+                "failed to get a consistent read output from file {} after {retries} retries",
+                path.display()
+            ),
+            Self::Nix(ref err) => write!(f, "{err}"),
+            Self::ConvertOsStrToStr { source: src } => {
+                write!(f, "failed to convert {:?} to &str", src)
+            }
+            Self::Semver(ref err) => write!(f, "semver error: {err}"),
+        }
+    }
+}
+impl Error for MountInfoError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {
+            Self::Io(ref err) => err.source(),
+            Self::Nix(ref err) => err.source(),
+            Self::Semver(ref err) => err.source(),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for MountInfoError {
+    fn from(io_err: std::io::Error) -> Self {
+        Self::Io(io_err)
+    }
+}
+
+impl From<nix::Error> for MountInfoError {
+    fn from(nix_err: nix::Error) -> Self {
+        Self::Nix(nix_err)
+    }
+}
+
+impl From<semver::Error> for MountInfoError {
+    fn from(semver_err: semver::Error) -> Self {
+        Self::Semver(semver_err)
+    }
+}

--- a/devinfo/src/mountinfo/io_utils.rs
+++ b/devinfo/src/mountinfo/io_utils.rs
@@ -1,0 +1,30 @@
+use crate::mountinfo::error::{MountInfoError, Result};
+use std::{fs::read, path::Path};
+
+const DEFAULT_RETRY_COUNT: u32 = 2;
+
+/// Issue std::fs::read on a file twice and compare the two byte sequences
+/// to see if the reads were consistent. Retry if the reads resulted in different byte
+/// sequences.
+pub(crate) fn consistent_read<P: AsRef<Path>>(
+    path: P,
+    retry_count: Option<u32>,
+) -> Result<Vec<u8>> {
+    let mut current_content = read(path.as_ref())?;
+
+    let retries = retry_count.unwrap_or(DEFAULT_RETRY_COUNT);
+    for _ in 0 ..= retries {
+        let new_content = read(path.as_ref())?;
+
+        if new_content.eq(&current_content) {
+            return Ok(new_content);
+        }
+
+        current_content = new_content;
+    }
+
+    Err(MountInfoError::InconsistentRead {
+        filepath: path.as_ref().to_path_buf(),
+        retries,
+    })
+}


### PR DESCRIPTION
Fixes https://github.com/openebs/mayastor/issues/1274

On the linux kernel versions below v5.8, there's a bug which behaves like so:
Whenever a read(2) syscall is issued (and this one takes an argument for how many bytes to read off of a file) to the `/proc/mounts` virtual file, few of the mount entries are read off of it. The kernel maintains the seek position of the file so that it can serve subsequent read(2)s from that position. But, in between the first and the second read(2), a device might be unmounted and one/few mount entries might be removed from the already-read portion of the file. This moves the mount entries after the deleted entries further up the file. However, the seek position has not changed. So, subsequent read(2)s will miss one or more read entries, as the seek position now points to a mount entry further down the list.
Ref: https://github.com/torvalds/linux/commit/9f6c61f96f2d97cbb5f7fa85607bc398f843ff0f

Changes:
This PR adds a `consistent_read()` implementation for the interface `MountIter` for kernel versions less than 5.8.0. `consistent_read()` reads the whole file twice start to end, and compares the two byte buffers. If both of the subsequent reads resulted in the same byte-sequence, then we can say we have not lost mount entries when traversing `/proc/mounts`, as then the comparison would fail on the second read from start to end. This is configured to default to 2 comparison retries if the first comparison fails. However that may not be enough if there are very many mount entries and the host has very frequent unmounts. Use higher retries for those cases.


