### PR TITLE
refactor(devinfo): make mountinfo APIs more accessable to caller

### DIFF
--- a/devinfo/src/mountinfo/bytebuf.rs
+++ b/devinfo/src/mountinfo/bytebuf.rs
@@ -1,7 +1,7 @@
 use std::io::{IoSliceMut, Read};
 
-/// This is io::Read capable Sized type. This can wrap around a Vec<u8>.
-pub struct ByteBuf {
+/// This is io::Read capable Sized type. This wraps around a Vec<u8>.
+pub(crate) struct ByteBuf {
     inner: Vec<u8>,
 }
 

--- a/devinfo/src/mountinfo/mod.rs
+++ b/devinfo/src/mountinfo/mod.rs
@@ -17,8 +17,11 @@ use std::{
     sync::OnceLock,
 };
 
+/// Contains a type which is Sized and implements io::Read.
+/// Useful as a Read-able alternative to a Vec<u8>.
 mod bytebuf;
-mod error;
+/// Errors for MountInfo affairs.
+pub mod error;
 /// Contains tools to interact with files, etc.
 mod io_utils;
 
@@ -226,7 +229,7 @@ impl<R: BufRead> Iterator for MountIter<R> {
     }
 }
 
-pub static SAFE_MOUNT_ITER: OnceLock<SafeMountIter> = OnceLock::new();
+static SAFE_MOUNT_ITER: OnceLock<SafeMountIter> = OnceLock::new();
 
 /// This returns a Result<Iterator> with reads /proc/mounts consistently.
 pub struct SafeMountIter {


### PR DESCRIPTION
Changes:
- Makes devinfo::mountinfo::error module 'pub' so that callers may access errors from this module.
- Makes the SAFE_MOUNT_ITER `OnceLock<SafeMountIter>`, ByteBuf struct and `MountIter<R>::new_from_readable()` private, as they aren't required outside of this module.