### PR TITLE
feat(callhome): add bustype and rotational properties to block device

### DIFF
--- a/apis/io-engine/protobuf/v1/host.proto
+++ b/apis/io-engine/protobuf/v1/host.proto
@@ -56,6 +56,8 @@ message BlockDevice {
   Partition partition = 9;      // partition information in case where device represents a partition
   Filesystem filesystem = 10;   // filesystem information in case where a filesystem is present
   bool available = 11;          // identifies if device is available for use (ie. is not "currently" in use)
+  string connection_type = 12;   // the type of bus through which the device is connected to the system
+  optional bool is_rotational = 13;     // indicates whether the device is rotational or non-rotational
 }
 
 message ListBlockDevicesRequest {


### PR DESCRIPTION
Added bus type("connection_type") and rotational ("is_rotational") properties to block device to be able to generate storage media metrics.

connection_type: the type of bus through which the device is connected to the system
is_rotational: indicates whether the device is rotational or non-rotational