### PR TITLE
feat(nvmeadm): allow overriding the hostid and the hostnqn prefix

### DIFF
--- a/composer/src/composer.rs
+++ b/composer/src/composer.rs
@@ -114,7 +114,7 @@ fn executable_path() -> PathBuf {
 }
 
 /// Path to local binary and arguments
-#[derive(Default, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct Binary {
     path: PathBuf,
     arguments: Vec<String>,
@@ -278,7 +278,7 @@ impl std::str::FromStr for ImagePullPolicy {
 
 /// Specs of the allowed containers include only the binary path
 /// (relative to src) and the required arguments
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct ContainerSpec {
     /// Name of the container
     name: ContainerName,
@@ -392,7 +392,11 @@ impl ContainerSpec {
     /// If a key already exists, the value is replaced
     pub fn with_env(mut self, key: &str, val: &str) -> Self {
         if let Some(old) = self.env.insert(key.into(), val.into()) {
-            println!("Replaced key {key} val {old} with val {val}");
+            if old.is_empty() {
+                tracing::trace!("Set key {key}");
+            } else {
+                tracing::trace!("Replaced key {key} val \"{old}\" with val \"{val}\"");
+            }
         }
         self
     }

--- a/devinfo/src/lib.rs
+++ b/devinfo/src/lib.rs
@@ -32,7 +32,7 @@ pub enum DevInfoError {
 pub fn basic() {
     use std::convert::TryFrom;
 
-    let path = "nvmf://fooo/nqn.2019-05.io.openebs:00000000-76b6-4fcf-864d-1027d4038756";
+    let path = "nvmf://fooo/nqn.2019-05.com.org:00000000-76b6-4fcf-864d-1027d4038756";
     let dev = BlkDev::try_from(path).unwrap();
     let path = dev.lookup();
     dbg!(&path);

--- a/nvmeadm/src/error.rs
+++ b/nvmeadm/src/error.rs
@@ -4,8 +4,11 @@ use snafu::Snafu;
 #[allow(missing_docs)]
 #[snafu(visibility(pub(crate)), context(suffix(false)), module(nvme_error))]
 pub enum NvmeError {
-    #[snafu(display("IO error:"))]
-    IoFailed { source: std::io::Error },
+    #[snafu(display("IO error: {source}, args: {args}"))]
+    IoFailed {
+        source: std::io::Error,
+        args: String,
+    },
     #[snafu(display("Failed to parse {}: {}, {}", path, contents, error))]
     ValueParseFailed {
         path: String,
@@ -65,6 +68,9 @@ pub enum NvmeError {
 
 impl From<std::io::Error> for NvmeError {
     fn from(source: std::io::Error) -> NvmeError {
-        NvmeError::IoFailed { source }
+        NvmeError::IoFailed {
+            source,
+            args: "".to_string(),
+        }
     }
 }

--- a/nvmeadm/src/lib.rs
+++ b/nvmeadm/src/lib.rs
@@ -53,7 +53,9 @@ where
     T::Err: ToString,
 {
     let path = dir.join(file);
-    let s = fs::read_to_string(&path).context(nvme_error::IoFailed {})?;
+    let s = fs::read_to_string(&path).context(nvme_error::IoFailed {
+        args: String::new(),
+    })?;
     let s = s.trim();
 
     match s.parse() {

--- a/nvmeadm/tests/discovery_test.rs
+++ b/nvmeadm/tests/discovery_test.rs
@@ -18,7 +18,7 @@ static CONFIG_TEXT: &str = "nexus_opts:
 
 const CONFIG_FILE: &str = "/tmp/nvmeadm_nvmf_target.yaml";
 
-const SERVED_DISK_NQN: &str = "nqn.2019-05.io.openebs:m0";
+const SERVED_DISK_NQN: &str = "nqn.2019-05.com.org:m0";
 
 const TARGET_PORT: u32 = 9523;
 


### PR DESCRIPTION
Also set default hostnqn to match the one set by nvme-cli. Recent kernels are more strict and don't allow mixing the initial connect with hostid/hostnqn with another.