### PR TITLE
feat: expose nexus rebuild fix

### DIFF
--- a/apis/io-engine/protobuf/v1/common.proto
+++ b/apis/io-engine/protobuf/v1/common.proto
@@ -7,3 +7,17 @@ enum ShareProtocol {
   NVMF = 1; // NVMe over Fabrics (TCP)
   ISCSI = 2; // iSCSI
 }
+
+message MayastorFeatures {
+  // NVMe ANA enablement status.
+  bool asymmetricNamespaceAccess = 1;
+  // LVM backend presence and enablement status.
+  optional bool logicalVolumeManager = 2;
+  // SnapshotRebuild presence and enablement status.
+  optional bool snapshotRebuild = 3;
+}
+
+message MayastorBugFixes {
+  // Nexus rebuilds both the clusters allocated to the replica and its ancestors clusters
+  bool nexusRebuildReplicaAncestry = 1;
+}

--- a/apis/io-engine/protobuf/v1/host.proto
+++ b/apis/io-engine/protobuf/v1/host.proto
@@ -20,16 +20,15 @@ service HostRpc {
   rpc StatNvmeController (StatNvmeControllerRequest) returns (StatNvmeControllerResponse) {}
 }
 
-message MayastorFeatures {
+message BackCompatMayastorFeatures {
+  // NVMe ANA enablement status.
   bool asymmetricNamespaceAccess = 1;
-  bool logicalVolumeManager = 2;
-  bool snapshotRebuild = 3;
 }
 
 message MayastorInfoResponse {
   string version = 1;
-  MayastorFeatures supportedFeatures = 2;
-  RegisterRequest registration_info = 3;
+  BackCompatMayastorFeatures previous_features = 2;
+  RegisterRequest  registration_info = 3;
 }
 
 message BlockDevice {

--- a/apis/io-engine/protobuf/v1/registration.proto
+++ b/apis/io-engine/protobuf/v1/registration.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
+import "common.proto";
 
 package mayastor.v1;
 
@@ -17,6 +18,12 @@ message RegisterRequest {
   repeated APIVersion api_version = 4;
   // nvme initiator hostnqn used by this instance
   google.protobuf.StringValue hostnqn = 5;
+  // Mayastor features.
+  optional MayastorFeatures features = 6;
+  // Mayastor bugfixes.
+  optional MayastorBugFixes bugfixes = 7;
+  // Version of mayastor.
+  optional string version = 8;
 }
 
 // api version supported by the dataplane

--- a/apis/io-engine/src/v1.rs
+++ b/apis/io-engine/src/v1.rs
@@ -64,17 +64,21 @@ pub mod snapshot {
     };
 }
 pub mod registration {
-    pub use super::pb::{registration_client, ApiVersion, DeregisterRequest, RegisterRequest};
+    pub use super::pb::{
+        registration_client, ApiVersion, DeregisterRequest, MayastorBugFixes, MayastorFeatures,
+        RegisterRequest,
+    };
 }
 pub mod host {
     pub use super::pb::{
         block_device::{Filesystem, Partition},
         host_rpc_client::HostRpcClient,
         host_rpc_server::{HostRpc, HostRpcServer},
-        BlockDevice, GetMayastorResourceUsageResponse, ListBlockDevicesRequest,
-        ListBlockDevicesResponse, ListNvmeControllersResponse, MayastorFeatures,
-        MayastorInfoResponse, NvmeController, NvmeControllerIoStats, NvmeControllerState,
-        ResourceUsage, StatNvmeControllerRequest, StatNvmeControllerResponse,
+        BackCompatMayastorFeatures, BlockDevice, GetMayastorResourceUsageResponse,
+        ListBlockDevicesRequest, ListBlockDevicesResponse, ListNvmeControllersResponse,
+        MayastorBugFixes, MayastorFeatures, MayastorInfoResponse, NvmeController,
+        NvmeControllerIoStats, NvmeControllerState, ResourceUsage, StatNvmeControllerRequest,
+        StatNvmeControllerResponse,
     };
 }
 


### PR DESCRIPTION
This is useful to ensure nexus rebuild is done correctly, copying all the clusters from an existing replica.