### PR TITLE
chore: implement FromStr trait for TrType

### DIFF
--- a/nvmeadm/src/nvmf_discovery.rs
+++ b/nvmeadm/src/nvmf_discovery.rs
@@ -73,6 +73,19 @@ impl fmt::Display for TrType {
     }
 }
 
+impl FromStr for TrType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "rdma" => Ok(Self::rdma),
+            "tcp" => Ok(Self::tcp),
+            "fc" => Ok(Self::fc),
+            invalid => Err(format!("Invalid transport type: {invalid}")),
+        }
+    }
+}
+
 /// AddressFamily, in case of TCP and RDMA we use IPv6 or IPc4 only
 #[derive(Clone, Debug, Primitive)]
 pub enum AddressFamily {


### PR DESCRIPTION
This will be used to decide TrType variant based on Attach trait values in the nvmf connect/attachment path.