### PR TITLE
fix tini bind-mounted path and add logging knobs

### DIFF
--- a/composer/src/composer.rs
+++ b/composer/src/composer.rs
@@ -526,7 +526,7 @@ impl ContainerSpec {
         if let Some(entrypoint) = &self.entrypoint {
             entrypoint.clone()
         } else if self.binary.is_some() && default_image.is_some() && self.init.unwrap_or(true) {
-            vec!["tini".to_string(), "--".to_string()]
+            vec!["/sbin/tini".to_string(), "--".to_string()]
         } else {
             vec![]
         }


### PR DESCRIPTION
    feat(composer): allow control of rust logging
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

    fix(composer): use tini bind-mounted path
    
    Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>
