### PR TITLE
build: upgrade nix-shell helm to v3.15.4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "helm-nixpkgs": {
+        "branch": "master",
+        "description": "Nix Packages collection & NixOS",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6e521c81bdf97fa70326bb88b007879bf9b226bf",
+        "sha256": "0ilczcqv88yjlqx7j2lg3csyl1aaq3ackd9gmmsnwydj9y96ikp7",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6e521c81bdf97fa70326bb88b007879bf9b226bf.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "release-24.05",
         "description": "Nix Packages collection",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -399,7 +399,7 @@ exec_helm() {
   if [ -n "$LOCAL_HELM" ]; then
     $HELM $@
   else
-    $NIX_SHELL -p "(import (import $NIX_SOURCES).nixpkgs {}).kubernetes-helm-wrapped" --run "$HELM $@"
+    $NIX_SHELL -p "(import (import $NIX_SOURCES).helm-nixpkgs {}).kubernetes-helm" --run "$HELM $@"
   fi
 }
 


### PR DESCRIPTION
Helm's upgrade option --reset-then-reuse-values requires helm 3.14 or above. Using Helm v3.15.4 across the Mayastor repos to support use for this option in the upgrade-job and/or E2e tests.