### PR TITLE
chore: move platform crate to dependencies

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "platform"
+version = "0.1.0"
+edition = "2021"
+description = "A library used to identify which platfrom we're running under."
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { version = "1.41.0", features = ["full"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
+kube = { version = "0.94.2", features = ["derive"] }
+tracing = "0.1.40"

--- a/platform/src/deployer/mod.rs
+++ b/platform/src/deployer/mod.rs
@@ -1,0 +1,25 @@
+use crate::{PlatformInfo, PlatformNS, PlatformUid};
+
+/// No specific platform (deployer cluster using containers).
+/// Internally works as `None` platform.
+pub(super) struct Deployer(super::none::None);
+
+impl Deployer {
+    /// Create a new `Self`.
+    pub(super) fn new() -> Self {
+        Self(super::none::None::new())
+    }
+    fn none(&self) -> &super::none::None {
+        &self.0
+    }
+}
+
+impl PlatformInfo for Deployer {
+    fn uid(&self) -> PlatformUid {
+        self.none().uid()
+    }
+
+    fn namespace(&self) -> &PlatformNS {
+        self.none().namespace()
+    }
+}

--- a/platform/src/k8s/mod.rs
+++ b/platform/src/k8s/mod.rs
@@ -1,0 +1,65 @@
+use crate::{PlatformError, PlatformInfo, PlatformNS, PlatformUid};
+
+use k8s_openapi::api::core::v1::Namespace;
+use kube::{Api, Client, Resource};
+
+/// Kubernetes Platform.
+pub struct K8s {
+    platform_uuid: PlatformUid,
+    platform_ns: PlatformNS,
+}
+impl K8s {
+    /// Create new `Self`.
+    pub(super) async fn new() -> Result<Self, PlatformError> {
+        let client = Client::try_default()
+            .await
+            .map_err(|e| format!("Can't connect to k8s api-server: {e}"))?;
+        Self::from(client).await
+    }
+    /// Create new `Self` from a given `Client`.
+    pub async fn from(client: Client) -> Result<Self, PlatformError> {
+        let platform_uuid = Self::fetch_platform_uuid(client).await?;
+        // todo: should we use the default namespace from the client?
+        let platform_ns = std::env::var("MY_POD_NAMESPACE").unwrap_or_else(|_| "default".into());
+        Ok(Self {
+            platform_uuid,
+            platform_ns,
+        })
+    }
+    /// Create new `Self` from a given `Client` and namespace.
+    /// This may be necessary if we're running outside of the cluster itself, which
+    /// means that MY_POD_NAMESPACE itself is not available... Perhaps using a client
+    /// configured with the namespace as default would be better.
+    pub async fn from_custom(client: Client, namespace: &str) -> Result<Self, PlatformError> {
+        let platform_uuid = Self::fetch_platform_uuid(client).await?;
+        Ok(Self {
+            platform_uuid,
+            platform_ns: namespace.to_string(),
+        })
+    }
+    async fn fetch_platform_uuid(client: Client) -> Result<PlatformUid, PlatformError> {
+        let namespaces: Api<Namespace> = Api::all(client);
+        let ns = namespaces
+            .get("kube-system")
+            .await
+            .map_err(|e| format!("Failed to get kube-system namespace: {e}"))?;
+
+        match &ns.meta().uid {
+            None => Err("The kube-system namespace has no UID".to_string()),
+            Some(uid) if uid.is_empty() => {
+                Err("The kube-system namespace has an empty UID".to_string())
+            }
+            Some(uid) => Ok(uid.into()),
+        }
+    }
+}
+
+impl PlatformInfo for K8s {
+    fn uid(&self) -> PlatformUid {
+        self.platform_uuid.clone()
+    }
+
+    fn namespace(&self) -> &PlatformNS {
+        &self.platform_ns
+    }
+}

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -1,0 +1,96 @@
+use std::ops::Deref;
+use tokio::{runtime::Builder, sync::OnceCell};
+
+mod deployer;
+/// K8S Platform Information.
+pub mod k8s;
+mod none;
+
+/// Platform Unique identifier.
+pub type PlatformUid = String;
+/// Platform Namespace.
+pub type PlatformNS = String;
+/// Platform Error.
+pub type PlatformError = String;
+
+/// Common Platform information.
+pub trait PlatformInfo: Send + Sync {
+    /// Get the platform `PlatformUid`.
+    fn uid(&self) -> PlatformUid;
+    /// Get the platform `PlatformNS`.
+    fn namespace(&self) -> &PlatformNS;
+}
+
+#[derive(Eq, PartialEq)]
+/// The various types of platforms.
+pub enum PlatformType {
+    /// As it says in the tin.
+    K8s,
+    /// Deployer cluster in containers.
+    Deployer,
+    /// We don't have others, other than running the binary directly or on deployer "clusters".
+    None,
+}
+
+/// Get the current `PlatformType`.
+pub fn current_platform_type() -> PlatformType {
+    if std::env::var("KUBERNETES_SERVICE_HOST").is_ok() {
+        PlatformType::K8s
+    } else {
+        match std::env::var("PLATFORM_TYPE").unwrap_or_default().as_str() {
+            "deployer" => PlatformType::Deployer,
+            _ => PlatformType::None,
+        }
+    }
+}
+
+/// Cached Platform information.
+static PLATFORM: OnceCell<Box<dyn PlatformInfo>> = OnceCell::const_new();
+
+/// Init the cached `PlatformInfo` object.
+pub async fn init_cluster_info() -> Result<&'static dyn PlatformInfo, PlatformError> {
+    PLATFORM
+        .get_or_try_init(|| async move {
+            Ok(match current_platform_type() {
+                PlatformType::K8s => Box::new(k8s::K8s::new().await?) as Box<dyn PlatformInfo>,
+                PlatformType::Deployer => {
+                    Box::new(deployer::Deployer::new()) as Box<dyn PlatformInfo>
+                }
+                PlatformType::None => Box::new(none::None::new()) as Box<dyn PlatformInfo>,
+            })
+        })
+        .await
+        .map(|i| i.deref())
+}
+
+/// Init the cached `PlatformInfo` object or panic.
+pub async fn init_cluster_info_or_panic() -> &'static dyn PlatformInfo {
+    match init_cluster_info().await {
+        Ok(info) => info,
+        Err(error) => {
+            let message = "Failed to collect critical information from the platform";
+            tracing::error!(error=%error, message);
+            panic!("{message}: {error}")
+        }
+    }
+}
+
+/// Get a cached `PlatformInfo` object.
+pub fn platform_info() -> &'static dyn PlatformInfo {
+    if let Some(platform) = PLATFORM.get() {
+        return platform.as_ref();
+    }
+
+    tracing::warn!("PlatformInfo should be pre-initialized before use");
+
+    // only when we don't pre initialize and on the first iteration/(concurrent ones) do we fall
+    // through here.
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Should get a runtime");
+    let thread =
+        std::thread::spawn(move || rt.block_on(async move { init_cluster_info_or_panic().await }));
+
+    thread.join().expect("thread should not panic")
+}

--- a/platform/src/none/mod.rs
+++ b/platform/src/none/mod.rs
@@ -1,0 +1,42 @@
+use crate::{PlatformInfo, PlatformNS, PlatformUid};
+
+/// No specific platform.
+/// Attempt to retrieve the platform uuid from (in order):
+/// env var `NOPLATFORM_UUID_VAR`
+/// machine id file `MACHINE_ID`
+/// hardcoded from var `DUMMY_PLATFORM_UUID`
+pub(super) struct None {
+    platform_uuid: PlatformUid,
+    platform_ns: PlatformNS,
+}
+
+const MACHINE_ID: &str = "/etc/machine-id";
+const NOPLATFORM_UUID_VAR: &str = "NOPLATFORM_UUID";
+const DUMMY_PLATFORM_UUID: &str = "dummy-uuid";
+const DUMMY_PLATFORM_NS: &str = "default";
+
+impl None {
+    /// Create a new `Self`.
+    pub(super) fn new() -> Self {
+        let platform_uuid = if let Ok(uuid) = std::env::var(NOPLATFORM_UUID_VAR) {
+            uuid
+        } else {
+            std::fs::read_to_string(MACHINE_ID).unwrap_or_else(|_| DUMMY_PLATFORM_UUID.to_string())
+        };
+
+        Self {
+            platform_uuid: platform_uuid.trim().to_string(),
+            platform_ns: PlatformNS::from(DUMMY_PLATFORM_NS),
+        }
+    }
+}
+
+impl PlatformInfo for None {
+    fn uid(&self) -> PlatformUid {
+        self.platform_uuid.clone()
+    }
+
+    fn namespace(&self) -> &PlatformNS {
+        &self.platform_ns
+    }
+}


### PR DESCRIPTION
- Moves the platform crate to dependencies so that it can be used by both control-plane and data-plane