### PR TITLE
fix(nvme): remove [ ] from the host

### DIFF
--- a/nvmeadm/src/nvme_uri.rs
+++ b/nvmeadm/src/nvme_uri.rs
@@ -41,6 +41,8 @@ impl TryFrom<&str> for NvmeTarget {
             .ok_or(NvmeError::InvalidUri {
                 source: ParseError::EmptyHost,
             })?
+            .trim_start_matches("[")
+            .trim_end_matches("]")
             .into();
 
         let subnqn = match url.path_segments() {


### PR DESCRIPTION
The Url crate keeps the [ ] when it returns the host so we need to remove it ourselves.