### PR TITLE
build: remove step to unpack helm chart tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@ Cargo.lock
 /package.json
 /rust-git-version
 /rust-toolchain.toml
-.idea
+**/.idea
 .vscode
 .pregenerated

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -431,15 +431,10 @@ build_helm_deps() {
   local chart_dir=${HELM_CHART_DIR%/}
   local dep_chart_dir="$chart_dir/charts"
 
-  # This performs a dependency update and then extracts the tarballs pulled.
-  # If and when the `--untar` functionality is added to the `helm dependency
-  # update command, the for block can be removed in favour of the `--untar` option.
-  # Ref: https://github.com/helm/helm/issues/8479
+  # Helm dependency update doesn't work correctly if a version of a dependency is newer than the required version
+  # This rm command clears out existing chart tarballs, so that helm dependency update works correctly.
+  rm -f "$dep_chart_dir"/*.tgz
   exec_helm "dependency update $chart_dir"
-  for dep_chart_tar in "$dep_chart_dir"/*.tgz; do
-    $TAR -xf "$dep_chart_tar" -C "$dep_chart_dir"
-    $RM -f "$dep_chart_tar"
-  done
 }
 
 build_images() {


### PR DESCRIPTION
The mayastor upgrade-job reads through helm dependency chart values. The
build step which performs the helm dependency update also unpacks the
dependency chart tarballs.

Helm works in unexpected ways if there exists a tarball and a directory
for the same dependency chart, both in the charts directory.

The mayastor upgrade-job could unpack the tarballs in its own nix build
sandbox. Alternatively, it could use the helm show values command.