### PR TITLE
add CAP_SYS_RESOURCE capability to Docker containers

### DIFF
--- a/composer/src/composer.rs
+++ b/composer/src/composer.rs
@@ -1400,6 +1400,7 @@ impl ComposeTest {
                 "SYS_ADMIN".to_string(),
                 "IPC_LOCK".into(),
                 "SYS_NICE".into(),
+                "SYS_RESOURCE".into(),
             ]),
             privileged: spec.privileged(),
             security_opt: Some(vec!["seccomp=unconfined".into()]),


### PR DESCRIPTION
- Add SYS_RESOURCE to cap_add list for io-engine containers
- Required for PR_SET_IO_FLUSHER system call to succeed
- Fixes 'Operation not permitted' errors in container-based tests