### PR TITLE
build: use shared workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,66 @@
+[patch.crates-io]
+h2 = { path = "./h2" }
+
+[profile.dev]
+panic = "abort"
+debug = false
+
+[workspace]
+members = [
+    "apis/events",
+    "apis/io-engine",
+    "composer",
+    "devinfo",
+    "event-publisher",
+    "git-version-macro",
+    "nvmeadm",
+    "platform",
+    "nvmeadm",
+    "secret-provider",
+    "sysfs",
+    "tracing-filter",
+    "version-info",
+]
+resolver = "1"
+
+[workspace.dependencies]
+prost-extend = { path = "./prost-extend" }
+
+tokio = "1.45.1"
+futures = "0.3.31"
+
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+
+once_cell = "1.20.2"
+async-trait = "0.1.73"
+
+serde = "1.0.214"
+serde_json = "1.0.132"
+
+snafu = "0.8.5"
+url = "2.5.4"
+uuid = { version = "1.4.1", features = ["v4"] }
+chrono = "0.4.38"
+glob = "0.3.1"
+
+strum = "0.26.3"
+strum_macros = "0.26.4"
+heck = "0.5.0"
+
+tonic = "0.12.3"
+tonic-build = "0.12.3"
+prost-types = "0.13.3"
+prost = "0.13.2"
+prost-derive = "0.13.3"
+bytes = "1.8.0"
+prost-build = "0.13.3"
+
+udev = "0.9.1"
+bindgen = "0.69.5"
+nix = { version = "0.29.0", default-features = false }
+ipnetwork = "0.20.0"
+bollard = "0.17.1"
+semver = "1.0.23"
+
+async-nats = { version = "0.37.0", default-features = false }

--- a/apis/events/Cargo.toml
+++ b/apis/events/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 
 [build-dependencies]
-tonic-build = "0.12.3"
+tonic-build = { workspace = true }
 
 [features]
 default = ["rls-ring"]
@@ -13,18 +13,17 @@ rls-aws-lc-rs = ["async-nats/aws-lc-rs"]
 rls-ring = ["async-nats/ring"]
 
 [dependencies]
-async-nats = { version = "0.37.0", default-features = false }
-bytes = "1.8.0"
-serde = "1.0.214"
-serde_json = "1.0.132"
-tokio = "1.41.0"
-tracing = "0.1.40"
-uuid = { version = "1.11.0", features = ["v4"] }
-async-trait = "0.1.83"
-futures = "0.3.31"
-snafu = "0.8.5"
-tonic = "0.12.3"
-prost = "0.13.3"
-chrono = "0.4.38"
-once_cell = "1.20.2"
+async-nats = { workspace = true, default-features = false }
+bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+async-trait = { workspace = true }
+futures = { workspace = true }
+snafu = { workspace = true }
+tonic = { workspace = true }
+prost = { workspace = true }
+chrono = { workspace = true }
 prost-extend = { path = "../../prost-extend" }

--- a/apis/io-engine/Cargo.toml
+++ b/apis/io-engine/Cargo.toml
@@ -4,16 +4,15 @@ version = "1.0.0"
 edition = "2021"
 
 [build-dependencies]
-tonic-build = "0.12.3"
-prost-build = "0.13.3"
+tonic-build = { workspace = true }
+prost-build = { workspace = true }
 
 [dependencies]
-tonic = "0.12.3"
-bytes = "1.8.0"
-prost = "0.13.3"
-prost-derive = "0.13.3"
+tonic = { workspace = true }
+bytes = { workspace = true }
+prost = { workspace = true }
+prost-derive = { workspace = true }
 prost-extend = { path = "../../prost-extend" }
-prost-types = "0.13.3"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_derive = "1.0.214"
-serde_json = "1.0.132"
+prost-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }

--- a/composer/Cargo.toml
+++ b/composer/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.41.0", features = ["full"] }
-futures = "0.3.31"
-tracing = "0.1.40"
-once_cell = "1.20.2"
-ipnetwork = "0.20.0"
-bollard = "0.17.1"
-strum = "0.26"
-strum_macros = "0.26"
+tokio = { workspace = true, features = ["full"] }
+futures = { workspace = true }
+tracing = { workspace = true }
+once_cell = { workspace = true }
+ipnetwork = { workspace = true }
+bollard = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }

--- a/devinfo/Cargo.toml
+++ b/devinfo/Cargo.toml
@@ -4,13 +4,13 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-nix = { version = "0.29.0", default-features = false, features = ["feature"] }
-semver = "1.0.23"
-snafu = "0.8.5"
-url = "2.5.2"
-uuid = { version = "1.11.0", features = ["v4"] }
+nix = { workspace = true, default-features = false, features = ["feature"] }
+semver = { workspace = true }
+snafu = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = { workspace = true }
 
 [target.'cfg(target_os="linux")'.dependencies]
-udev = "0.9.1"
+udev = { workspace = true }

--- a/event-publisher/Cargo.toml
+++ b/event-publisher/Cargo.toml
@@ -9,8 +9,8 @@ rls-aws-lc-rs = ["events-api/rls-aws-lc-rs"]
 rls-ring = ["events-api/rls-ring"]
 
 [dependencies]
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tokio = { version = "1.41.0" }
-tracing = "0.1.40"
-serde_json = "1.0.132"
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio = { workspace = true }
+tracing = { workspace = true }
+serde_json = { workspace = true }
 events-api = { path = "../apis/events", default-features = false }

--- a/nvmeadm/Cargo.toml
+++ b/nvmeadm/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 [dependencies]
 derive_builder = "0.20.2"
 enum-primitive-derive = "0.3.0"
-glob = "0.3.1"
+glob = { workspace = true }
 ioctl-gen = "0.1.1"
 libc = "0.2.161"
-nix = { version = "0.29.0", default-features = false, features = [ "ioctl" ] }
+nix = { workspace = true, default-features = false, features = ["ioctl"] }
 num-traits = "0.2.19"
-once_cell = "1.20.2"
-snafu = "0.8.5"
-uuid = { version = "1.11.0", features = ["v4"] }
-url = "2.5.2"
+once_cell = { workspace = true }
+snafu = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+url = { workspace = true }

--- a/scripts/rust/linter.sh
+++ b/scripts/rust/linter.sh
@@ -2,8 +2,4 @@
 
 set -euo pipefail
 
-for d in `find -maxdepth 3 -name Cargo.toml -printf '%h\n' | grep -v "^./h2"`; do
-    pushd $d
-    cargo-clippy --all --all-targets -- -D warnings
-    popd
-done
+cargo-clippy --all --all-targets -- -D warnings

--- a/scripts/rust/style.sh
+++ b/scripts/rust/style.sh
@@ -4,8 +4,4 @@ set -euo pipefail
 
 FMT_OPTS=${FMT_OPTS:-"--config imports_granularity=Crate"}
 
-for d in `find -maxdepth 3 -name Cargo.toml -printf '%h\n' | grep -v "^./h2" | grep -v "git-version-macro"`; do
-    pushd $d
-    cargo-fmt --all -- $FMT_OPTS
-    popd
-done
+cargo-fmt --all -- $FMT_OPTS


### PR DESCRIPTION
This will make crate upgrades easier to maintain.