### PR TITLE
fix: add hot-removal child fault

### DIFF
--- a/apis/io-engine/protobuf/v1/nexus.proto
+++ b/apis/io-engine/protobuf/v1/nexus.proto
@@ -104,6 +104,7 @@ enum ChildStateReason {
   CHILD_STATE_REASON_NO_SPACE = 9;        // child faulted because I/O operation failed with ENOSPC
   CHILD_STATE_REASON_TIMED_OUT = 10;      // child faulted because I/O operation failed with timeout
   CHILD_STATE_REASON_ADMIN_FAILED = 11;   // child faulted of an admin command failure
+  CHILD_STATE_REASON_HOT_REMOVED = 12;    // child hot-removed under the nexus (ie mistaken lvol destroy or pool hot-removal)
 }
 
 // represents a child device part of a nexus


### PR DESCRIPTION
This can happen when bdev is hot-removed under the nexus.