### PR TITLE
build: drop ring feature and dep

### DIFF
--- a/.github/workflows/pr-rust-lint.yaml
+++ b/.github/workflows/pr-rust-lint.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: cargo-clippy
         run: nix-shell --pure --run ./scripts/rust/linter.sh
       - name: cargo-fmt
-        run: nix-shell --pure --run "FMT_OPTS=--check ./scripts/rust/style.sh"
+        run: nix-shell --pure --run ./scripts/rust/style.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "1"
 [workspace.dependencies]
 prost-extend = { path = "./prost-extend" }
 
-tokio = "1.45.1"
+tokio = { version = "1.45.1", default-features = false }
 futures = "0.3.31"
 
 tracing = "0.1.40"
@@ -63,4 +63,7 @@ ipnetwork = "0.20.0"
 bollard = "0.17.1"
 semver = "1.0.23"
 
-async-nats = { version = "0.37.0", default-features = false }
+async-nats = { version = "0.39.0", default-features = false }
+
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_24", "schemars"] }
+kube = { version = "0.94.2", default-features = false, features = ["runtime", "derive", "client"] }

--- a/apis/events/Cargo.toml
+++ b/apis/events/Cargo.toml
@@ -8,9 +8,8 @@ edition = "2021"
 tonic-build = { workspace = true }
 
 [features]
-default = ["rls-ring"]
+default = ["rls-aws-lc-rs"]
 rls-aws-lc-rs = ["async-nats/aws-lc-rs"]
-rls-ring = ["async-nats/ring"]
 
 [dependencies]
 async-nats = { workspace = true, default-features = false }

--- a/event-publisher/Cargo.toml
+++ b/event-publisher/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["rls-ring"]
+default = ["rls-aws-lc-rs"]
 rls-aws-lc-rs = ["events-api/rls-aws-lc-rs"]
-rls-ring = ["events-api/rls-ring"]
 
 [dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -7,7 +7,7 @@ description = "A library used to identify which platfrom we're running under."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.41.0", features = ["full"] }
-k8s-openapi = { version = "0.22.0", features = ["v1_24"] }
-kube = { version = "0.94.2", features = ["derive"] }
-tracing = "0.1.40"
+tokio = { workspace = true }
+tracing = { workspace = true }
+k8s-openapi = { workspace = true }
+kube = { workspace = true }

--- a/scripts/rust/style.sh
+++ b/scripts/rust/style.sh
@@ -4,4 +4,5 @@ set -euo pipefail
 
 FMT_OPTS=${FMT_OPTS:-"--config imports_granularity=Crate"}
 
+cargo-fmt --all --check -- $FMT_OPTS
 cargo-fmt --all -- $FMT_OPTS

--- a/shell.nix
+++ b/shell.nix
@@ -18,13 +18,12 @@ let
     });
 in
 with pkgs;
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   buildInputs = [
     rust-bin
     cacert
     cargo-udeps
     clang
-    openssl
     pkg-config
     protobuf
     udev


### PR DESCRIPTION
Drops the ring dependency altogether.
Ensures kube crates come from workspace so we can specify the actual features on the workspace.