### PR TITLE
feat: add pool_name label to replica stats

### DIFF
--- a/apis/io-engine/protobuf/v1/stats.proto
+++ b/apis/io-engine/protobuf/v1/stats.proto
@@ -40,6 +40,8 @@ message ReplicaIoStatsResponse {
 message ReplicaIoStats {
   optional string entity_id = 1; // Entity ID of the replica, If any.
   IoStats stats = 2; // IO stats of the replica.
+  optional string poolname = 3; // Name of the pool hosting this replica.
+  optional string pooluuid = 4; // UUID of the pool hosting this replica.
 }
 
 // Common IO stats struct for all resource types.


### PR DESCRIPTION
Part of series of changes to add pool_name to `ReplicaIoStats`

Next changes in 
- `io-engine` populate `pool_name` from the replica's backing pool
- control-plane - submodule bump to pick up new proto
- mayastor-extensions — emit `pool_name` as a Prometheus label on replica I/O metrics

Motivation and Context:

Described at [#1990](https://github.com/openebs/mayastor/issues/1990)

Initial map based approach at https://github.com/openebs/mayastor-extensions/pull/860
