### PR TITLE
feat: make common and retry module public to expose BackoffOptions and backoff_with_options to external crates

### DIFF
--- a/apis/events/src/common.rs
+++ b/apis/events/src/common.rs
@@ -5,4 +5,4 @@ pub(crate) mod constants;
 pub(crate) mod errors;
 
 /// Retry module for jetstream server.
-pub(crate) mod retry;
+pub mod retry;

--- a/apis/events/src/lib.rs
+++ b/apis/events/src/lib.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use mbus_nats::{BusResult, BusSubscription};
 use serde::{de::DeserializeOwned, Serialize};
 
-mod common;
+pub mod common;
 pub mod event_traits;
 pub mod mbus_nats;
 


### PR DESCRIPTION
Make common and retry module public to expose BackoffOptions and backoff_with_options to external crates like event-consumer.