### PR TITLE
feat(nexus): add read_only field for ROX access mode

### DIFF
--- a/apis/io-engine/protobuf/v1/nexus.proto
+++ b/apis/io-engine/protobuf/v1/nexus.proto
@@ -232,6 +232,7 @@ message Nexus {
   repeated string allowed_hosts = 9; // host (nqn's) which are allowed to connect to the target
   optional NexusLabelVersion label_version = 10; // version of the nexus label layoyut
   optional uint64 bdev_size = 11; // the actual size of the nexus block device
+  optional bool read_only = 12; // true when the nexus is currently published as ROX and rejects writes
 }
 
 message CreateNexusResponse {
@@ -306,6 +307,11 @@ message PublishNexusRequest {
   string key = 2; // encryption key
   ShareProtocol share = 3;  // protocol used for the front end.
   repeated string allowed_hosts = 4; // host (nqn's) which are allowed to connect to the target.
+  // When true, the target rejects write I/O at submit time and skips acquiring
+  // write-exclusive reservations on the nexus children. Used for the
+  // ReadOnlyMany (ROX) access mode. Scoped to this publish; a re-publish with
+  // a different value flips the mode.
+  optional bool read_only = 5;
 }
 
 message PublishNexusResponse {


### PR DESCRIPTION
## Summary

Adds a `read_only` field to `PublishNexusRequest` and the `Nexus` query message in the io-engine v1 proto. First piece of the ROX-fs implementation per OEP openebs/openebs#4242.

## What

- `PublishNexusRequest.read_only` (field 5, `optional bool`): when true, the target rejects write I/O at submit time and skips acquiring write-exclusive reservations on the nexus children.
- `Nexus.read_only` (field 12, `optional bool`): reflects the currently-published state so the control plane can read it back.

Fully backwards-compatible (field is optional).

Scoped per publish, flipping between ROX and RWO is unshare + re-share with a different value, so no new mutation RPC is needed.

## Why

ROX (`MultiNodeReaderOnly`) needs N initiators to share a single read-only nexus. Write-exclusive reservations conflict with multi-host attach by construction, and the OEP calls for target-level write rejection as defense-in-depth against misconfigured mounts.

This PR is proto-only. The implementation that consumes the field will be added in openebs/mayastor (follow-up PR after this merges and the submodule bumps).

## Tracking

- OEP: openebs/openebs#4242
- OEP PR: openebs/openebs#4231
- Original feature request: openebs/mayastor#1993

cc @tiagolobocastro @Abhinandan-Purkait