### PR TITLE
feat(events-api): use pbjson for proto3 JSON enum serialization

### DIFF
--- a/apis/events/Cargo.toml
+++ b/apis/events/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [build-dependencies]
 tonic-build = { workspace = true }
+pbjson-build = "0.9.0"
 
 [features]
 default = ["rls-ring"]
@@ -27,3 +28,4 @@ tonic = { workspace = true }
 prost = { workspace = true }
 chrono = { workspace = true }
 prost-extend = { path = "../../prost-extend" }
+pbjson = "0.9.0"

--- a/apis/events/build.rs
+++ b/apis/events/build.rs
@@ -1,8 +1,21 @@
 fn main() {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("event_descriptor.bin");
+
     tonic_build::configure()
-        .type_attribute(".", "#[derive(serde::Deserialize, serde::Serialize)]")
+        .file_descriptor_set_path(&descriptor_path)
         .extern_path(".google.protobuf.Timestamp", "::prost_extend::Timestamp")
         .extern_path(".google.protobuf.Duration", "::prost_extend::Duration")
         .compile_protos(&["protobuf/v1/event.proto"], &["protobuf/"])
         .unwrap_or_else(|e| panic!("event v1 protobuf compilation failed: {e}"));
+
+    let descriptor_bytes = std::fs::read(&descriptor_path)
+        .unwrap_or_else(|e| panic!("failed to read event descriptor: {e}"));
+    pbjson_build::Builder::new()
+        .register_descriptors(&descriptor_bytes)
+        .unwrap_or_else(|e| panic!("failed to register event descriptors: {e}"))
+        .extern_path(".google.protobuf.Timestamp", "::prost_extend::Timestamp")
+        .extern_path(".google.protobuf.Duration", "::prost_extend::Duration")
+        .build(&[".v1.event"])
+        .unwrap_or_else(|e| panic!("pbjson serde generation failed: {e}"));
 }

--- a/apis/events/src/common.rs
+++ b/apis/events/src/common.rs
@@ -1,5 +1,5 @@
 /// Constants module for constants.
-pub(crate) mod constants;
+pub mod constants;
 
 /// Errors module for errors.
 pub(crate) mod errors;

--- a/apis/events/src/lib.rs
+++ b/apis/events/src/lib.rs
@@ -22,4 +22,5 @@ pub mod event {
     #![allow(clippy::derive_partial_eq_without_eq)]
     #![allow(clippy::large_enum_variant)]
     tonic::include_proto!("v1.event");
+    include!(concat!(env!("OUT_DIR"), "/v1.event.serde.rs"));
 }


### PR DESCRIPTION
- Integrate pbjson into the events-api build so protobuf enum fields serialize as human-readable string names instead of integer discriminants in JSON output
- Make the constants module in events_api::common public so downstream crates can import shared stream/subject constants

**Problem**

The existing tonic_build type_attribute approach derives standard serde::Serialize on generated structs. For protobuf enum fields, prost stores the value as i32 in the message struct, so JSON output contains raw integers:

`{"type":"mbus_event","subject":"events.1.8fa2379b-3e16-4f5f-a1d3-0e84e4175a5c","payload":{"category":1,"action":1,"target":"pool-on-node-0-477116","metadata":{"id":"8fa2379b-3e16-4f5f-a1d3-0e84e4175a5c","source":{"component":2,"node":"node-0-477116","event_details":null},"timestamp":"2026-06-29T09:48:57.437144286Z","version":1}}}`

This is unreadable in Loki/Grafana without knowing the enum mapping.

**Solution**

pbjson generates serde implementations that follow the proto3 JSON mapping spec — enums serialize as their variant name strings:

`{"type":"mbus_event","subject":"events.1.9db4b1c2-2170-4184-8714-11aec1ec6fc8","payload":{"category":"Pool","action":"Create","target":"pool-on-node-1-477116","metadata":{"id":"9db4b1c2-2170-4184-8714-11aec1ec6fc8","source":{"component":"IoEngine","node":"node-1-477116"},"timestamp":"2026-06-29T10:03:50.781662160Z","version":"V1"}}}`

**Impact**

- call-home and call-home-stats are unaffected — they consume EventMessage via prost binary encoding over NATS and pattern-match on enum variants, neither of which goes through serde
- Only JSON serialization of EventMessage changes, which is exclusively used by eventing-aggregator when writing events to stdout/file