### PR TITLE
feat(events-api): derive EnumIter, Display, EnumString on EventCategory and EventAction

### DIFF
--- a/apis/events/Cargo.toml
+++ b/apis/events/Cargo.toml
@@ -29,3 +29,5 @@ prost = { workspace = true }
 chrono = { workspace = true }
 prost-extend = { path = "../../prost-extend" }
 pbjson = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }

--- a/apis/events/build.rs
+++ b/apis/events/build.rs
@@ -6,6 +6,16 @@ fn main() {
         .file_descriptor_set_path(&descriptor_path)
         .extern_path(".google.protobuf.Timestamp", "::prost_extend::Timestamp")
         .extern_path(".google.protobuf.Duration", "::prost_extend::Duration")
+        .enum_attribute(
+            "v1.event.EventCategory",
+            "#[derive(strum_macros::EnumIter, strum_macros::Display, strum_macros::EnumString)]\
+             \n#[strum(serialize_all = \"kebab-case\")]",
+        )
+        .enum_attribute(
+            "v1.event.EventAction",
+            "#[derive(strum_macros::EnumIter, strum_macros::Display, strum_macros::EnumString)]\
+             \n#[strum(serialize_all = \"kebab-case\")]",
+        )
         .compile_protos(&["protobuf/v1/event.proto"], &["protobuf/"])
         .unwrap_or_else(|e| panic!("event v1 protobuf compilation failed: {e}"));
 


### PR DESCRIPTION
Add strum derives to the prost-generated EventCategory and EventAction enums so that callers can iterate variants, convert to/from kebab-case strings, and build validated CLI argument parsers without maintaining a hand-written mirror of the proto enum.

- strum, strum_macros added to events-api dependencies
- enum_attribute in build.rs adds EnumIter, Display, EnumString with serialize_all = kebab-case to both enums
- EventCategory::HighAvailability <-> high-availability round-trips via Display / FromStr without any manual impl