### PR TITLE
feat(events-api): add strum Display/EnumIter to Component and Rebuild Status

### DIFF
--- a/apis/events/build.rs
+++ b/apis/events/build.rs
@@ -16,6 +16,16 @@ fn main() {
             "#[derive(strum_macros::EnumIter, strum_macros::Display, strum_macros::EnumString)]\
              \n#[strum(serialize_all = \"kebab-case\")]",
         )
+        .enum_attribute(
+            "v1.event.Component",
+            "#[derive(strum_macros::EnumIter, strum_macros::Display)]\
+             \n#[strum(serialize_all = \"kebab-case\")]",
+        )
+        .enum_attribute(
+            "v1.event.RebuildStatus",
+            "#[derive(strum_macros::EnumIter, strum_macros::Display, strum_macros::EnumString)]\
+             \n#[strum(serialize_all = \"kebab-case\")]",
+        )
         .compile_protos(&["protobuf/v1/event.proto"], &["protobuf/"])
         .unwrap_or_else(|e| panic!("event v1 protobuf compilation failed: {e}"));
 


### PR DESCRIPTION

Add strum EnumIter + Display (kebab-case) to Component and RebuildStatus enums so the kubectl-mayastor plugin can iterate valid values and render them as CLI possible-values strings.

EnumString is omitted from Component because event_traits.rs already provides a FromStr impl mapping service names (e.g. agent-core) to variants; adding strum's EnumString would cause a conflicting impl error. RebuildStatus has no existing FromStr so gets all three derives.